### PR TITLE
re-organize README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,23 @@
 # ROS_Package_example
-## I. Cài đặt
-1.Trước tiên cần cài đặt Ubuntu 16.04 hoặc mới hơn.
-
-2.Lựa chọn 1 trong 2 phiên bản ROS sau:
-
-  Cài đặt ROS Lunar:
-  http://wiki.ros.org/lunar/Installation/Ubuntu
+## I. Installation
+1. Ubuntu 16.04 or newer
+2. One of these following version of [ROS](https://ros.org)
+    - [Lunar Loggerhead](http://wiki.ros.org/lunar)
+    - [Melodic Morenia](http://wiki.ros.org/melodic)
+    - It is recommended to install the full version
+      ```
+      $ sudo apt-get install ros-<distro>-desktop-full
+      ```
+3. Create catkin workspace
+    ```
+    $ mkdir -p ~/catkin_ws/src
+    $ cd ~/catkin_ws/
+    $ catkin_make
+    $ echo "source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc
+    $ source ~/.bashrc
+    ```
   
-  Cài đặt ROS Melodic:
-  http://wiki.ros.org/melodic/Installation/Ubuntu
-  
-  Chú ý: cần cài đặt bản đầy đủ. Ví dụ với ROS Lunar thì cài đặt bản đầy đủ như sau: 
-  
-  $sudo apt-get install ros-lunar-desktop-full
-  
-  Hoàn Thiện đầy đủ các bước từ mục 1.1 đến 1.7
-  
-3. Tạo ROS Workspace
-
-  $ mkdir -p ~/catkin_ws/src
-  
-  $ cd ~/catkin_ws/
-  
-  $ catkin_make
-  
-  $ echo "source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc
-
-  $ source ~/.bashrc
-  
-4. Cài đặt rosbridge-suite
-
-$ sudo apt-get install ros-lunar-rosbridge-server
+4. Install rosbridge-suite
+    ```
+    $ sudo apt-get install ros-<distro>-rosbridge-server
+    ```

--- a/README.vn.md
+++ b/README.vn.md
@@ -1,0 +1,33 @@
+# ROS_Package_example
+## I. Cài đặt
+1.Trước tiên cần cài đặt Ubuntu 16.04 hoặc mới hơn.
+
+2.Lựa chọn 1 trong 2 phiên bản ROS sau:
+
+  Cài đặt ROS Lunar:
+  http://wiki.ros.org/lunar/Installation/Ubuntu
+  
+  Cài đặt ROS Melodic:
+  http://wiki.ros.org/melodic/Installation/Ubuntu
+  
+  Chú ý: cần cài đặt bản đầy đủ. Ví dụ với ROS Lunar thì cài đặt bản đầy đủ như sau: 
+  
+  $sudo apt-get install ros-lunar-desktop-full
+  
+  Hoàn Thiện đầy đủ các bước từ mục 1.1 đến 1.7
+  
+3. Tạo ROS Workspace
+
+  $ mkdir -p ~/catkin_ws/src
+  
+  $ cd ~/catkin_ws/
+  
+  $ catkin_make
+  
+  $ echo "source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc
+
+  $ source ~/.bashrc
+  
+4. Cài đặt rosbridge-suite
+
+$ sudo apt-get install ros-lunar-rosbridge-server

--- a/unity/README.md
+++ b/unity/README.md
@@ -1,0 +1,17 @@
+B1. Chạy câu lệnh sau để khởi động sever:
+
+$ roslaunch lane_detect lane_detect.launch
+
+B2. Bật app unity, điền đầy đủ thông tin và ấn Connect.
+
+- Tên đội: Team1 
+- IP: ws://127.0.0.1:9090 hoặc ip của máy chủ ROS_MASTER
+
+B3. Chạy node xử lý ảnh.
+
+$ rosrun lane_detect lane_detect _image_transport:=compressed
+
+chú ý: để chạy được xe cần 3 topic. đổi tên topic theo tên đội và make lại bằng catkin_make
+- /Team1_speed : topic truyền tốc độ từ thuật toán lên xe để chạy
+- /Team1_steerAngle : Topic truyền góc lái cho xe
+- /Team1_image : Topic cho các đội thi subcriber ảnh từ phần mềm mô phỏng


### PR DESCRIPTION
I separate two versions of README.md for internationalization purpose and format code snippet.
Some packages are required with ROS may vary depend on the version of ROS. Example:
[ROS Melodic](http://wiki.ros.org/melodic) have `ros-melodic-rosbridge-server` package while [ROS Lunar](http://wiki.ros.org/lunar) have `ros-lunar-rosbridge-server` package.